### PR TITLE
DDBTEAM-392: Update box/spout from 2.x to 3.x

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,8 +10,7 @@ jobs:
                 uses: shivammathur/setup-php@master
                 with:
                     php-version: 7.3
-                    tools: pecl
-                    extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
+                    extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                     coverage: none
             -   name: Validate composer files
                 run: |
@@ -30,8 +29,7 @@ jobs:
               uses: shivammathur/setup-php@master
               with:
                   php-version: 7.3
-                  tools: pecl
-                  extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
+                  extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
             - name: Install Reviewdog
               run: |
@@ -53,8 +51,7 @@ jobs:
               uses: shivammathur/setup-php@master
               with:
                   php-version: 7.3
-                  tools: pecl
-                  extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
+                  extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
             - name: Install Dependencies
               run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,7 @@ jobs:
                 uses: shivammathur/setup-php@master
                 with:
                     php-version: 7.3
+                    tools: pecl
                     extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                     coverage: none
             -   name: Validate composer files
@@ -29,6 +30,7 @@ jobs:
               uses: shivammathur/setup-php@master
               with:
                   php-version: 7.3
+                  tools: pecl
                   extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
             - name: Install Reviewdog
@@ -51,6 +53,7 @@ jobs:
               uses: shivammathur/setup-php@master
               with:
                   php-version: 7.3
+                  tools: pecl
                   extension-csv: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
             - name: Install Dependencies

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-xmlreader": "*",
         "ext-zend-opcache": "*",
         "ext-zip": "*",
-        "box/spout": "^2.7",
+        "box/spout": "^3.0",
         "cloudinary/cloudinary_php": "^1.12",
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "eightpoints/guzzle-bundle": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc440c6ef59968b91103f9cd37564794",
+    "content-hash": "b4adc21da11d14cd7d904643e58e4d29",
     "packages": [
         {
             "name": "box/spout",
-            "version": "v2.7.3",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/box/spout.git",
-                "reference": "3681a3421a868ab9a65da156c554f756541f452b"
+                "reference": "7964dadc2128f3a00ffa393395b618ea115c8032"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/box/spout/zipball/3681a3421a868ab9a65da156c554f756541f452b",
-                "reference": "3681a3421a868ab9a65da156c554f756541f452b",
+                "url": "https://api.github.com/repos/box/spout/zipball/7964dadc2128f3a00ffa393395b618ea115c8032",
+                "reference": "7964dadc2128f3a00ffa393395b618ea115c8032",
                 "shasum": ""
             },
             "require": {
                 "ext-xmlreader": "*",
                 "ext-zip": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.0"
+                "friendsofphp/php-cs-fixer": "^2",
+                "phpunit/phpunit": "^7"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-intl\" is not already installed or is too limited)",
@@ -35,7 +36,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -72,7 +73,7 @@
                 "write",
                 "xlsx"
             ],
-            "time": "2017-09-25T19:44:35+00:00"
+            "time": "2019-12-02T21:21:41+00:00"
         },
         {
             "name": "ck/file_marc_reference",

--- a/src/Service/VendorService/EbookCentral/EbookCentralVendorService.php
+++ b/src/Service/VendorService/EbookCentral/EbookCentralVendorService.php
@@ -44,12 +44,8 @@ class EbookCentralVendorService extends AbstractBaseVendorService
      * @param string $resourcesDir
      *   The application resource dir
      */
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        EntityManagerInterface $entityManager,
-        LoggerInterface $statsLogger,
-        string $resourcesDir
-    ) {
+    public function __construct(EventDispatcherInterface $eventDispatcher, EntityManagerInterface $entityManager, LoggerInterface $statsLogger, string $resourcesDir)
+    {
         parent::__construct($eventDispatcher, $entityManager, $statsLogger);
 
         $this->resourcesDir = $resourcesDir;
@@ -144,7 +140,7 @@ class EbookCentralVendorService extends AbstractBaseVendorService
     }
 
     /**
-     * Get a xlsx filereader reference for the import source.
+     * Get a xlsx file reader reference for the import source.
      *
      * @return Reader
      *

--- a/src/Service/VendorService/Saxo/SaxoVendorService.php
+++ b/src/Service/VendorService/Saxo/SaxoVendorService.php
@@ -45,12 +45,8 @@ class SaxoVendorService extends AbstractBaseVendorService
      * @param string $resourcesDir
      *   The application resource dir
      */
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        EntityManagerInterface $entityManager,
-        LoggerInterface $statsLogger,
-        string $resourcesDir
-    ) {
+    public function __construct(EventDispatcherInterface $eventDispatcher, EntityManagerInterface $entityManager, LoggerInterface $statsLogger, string $resourcesDir)
+    {
         parent::__construct($eventDispatcher, $entityManager, $statsLogger);
 
         $this->resourcesDir = $resourcesDir;
@@ -127,7 +123,7 @@ class SaxoVendorService extends AbstractBaseVendorService
     }
 
     /**
-     * Get a xlsx filereader reference for the import source.
+     * Get a xlsx file reader reference for the import source.
      *
      * @return Reader
      *

--- a/src/Service/VendorService/Saxo/SaxoVendorService.php
+++ b/src/Service/VendorService/Saxo/SaxoVendorService.php
@@ -12,9 +12,7 @@ use App\Service\VendorService\AbstractBaseVendorService;
 use App\Service\VendorService\ProgressBarTrait;
 use App\Utils\Message\VendorImportResultMessage;
 use Box\Spout\Common\Exception\IOException;
-use Box\Spout\Common\Exception\UnsupportedTypeException;
-use Box\Spout\Common\Type;
-use Box\Spout\Reader\ReaderFactory;
+use Box\Spout\Reader\Common\Creator\ReaderEntityFactory;
 use Box\Spout\Reader\XLSX\Reader;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -47,9 +45,12 @@ class SaxoVendorService extends AbstractBaseVendorService
      * @param string $resourcesDir
      *   The application resource dir
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, EntityManagerInterface $entityManager,
-                                LoggerInterface $statsLogger, string $resourcesDir)
-    {
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+        EntityManagerInterface $entityManager,
+        LoggerInterface $statsLogger,
+        string $resourcesDir
+    ) {
         parent::__construct($eventDispatcher, $entityManager, $statsLogger);
 
         $this->resourcesDir = $resourcesDir;
@@ -74,7 +75,9 @@ class SaxoVendorService extends AbstractBaseVendorService
 
             foreach ($reader->getSheetIterator() as $sheet) {
                 foreach ($sheet->getRowIterator() as $row) {
-                    $isbn = (string) $row[0];
+                    $cellsArray = $row->getCells();
+                    $isbn = (string) $cellsArray[0]->getValue();
+
                     if (!empty($isbn)) {
                         $isbnArray[$isbn] = $this->getVendorsImageUrl($isbn);
                     }
@@ -124,12 +127,11 @@ class SaxoVendorService extends AbstractBaseVendorService
     }
 
     /**
-     * Get a reference a xlsx filereader reference for the import source.
+     * Get a xlsx filereader reference for the import source.
      *
      * @return Reader
      *
      * @throws IOException
-     * @throws UnsupportedTypeException
      */
     private function getSheetReader(): Reader
     {
@@ -138,7 +140,7 @@ class SaxoVendorService extends AbstractBaseVendorService
         $fileLocator = new FileLocator($resourceDirectories);
         $filePath = $fileLocator->locate(self::VENDOR_ARCHIVE_NAME, null, true);
 
-        $reader = ReaderFactory::create(Type::XLSX);
+        $reader = ReaderEntityFactory::createXLSXReader();
         $reader->open($filePath);
 
         return $reader;


### PR DESCRIPTION
Update `box/spout` from 2.x to 3.x. Fix backwards-incompatible changes: https://github.com/box/spout/blob/master/UPGRADE-3.0.md