### PR TITLE
DDBTEAM-421: More specific search for matches in OpenPlatform

### DIFF
--- a/.env
+++ b/.env
@@ -33,7 +33,6 @@ OPENPLATFORM_AUTH_AGENCY=DK-775100
 # Configuration used to get information from open search through the open
 # platform.
 OPENPLATFORM_SEARCH_URL=https://openplatform.dbc.dk/v3/search
-OPENPLATFORM_SEARCH_INDEX='dkcclterm.is'
 OPENPLATFORM_SEARCH_TTL=86400
 OPENPLATFORM_SEARCH_PROFILE=allekilder
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,7 +11,6 @@ parameters:
     openPlatform.auth.url: '%env(OPENPLATFORM_AUTH_URL)%'
     openPlatform.auth.agency: '%env(OPENPLATFORM_AUTH_AGENCY)%'
     openPlatform.search.url: '%env(OPENPLATFORM_SEARCH_URL)%'
-    openPlatform.search.index: '%env(OPENPLATFORM_SEARCH_INDEX)%'
     openPlatform.search.ttl: '%env(OPENPLATFORM_SEARCH_TTL)%'
     openPlatform.search.profile: '%env(OPENPLATFORM_SEARCH_PROFILE)%'
     datawell.vendor.agency: '%env(DATAWELL_VENDOR_AGENCY)%'

--- a/src/Service/OpenPlatform/SearchService.php
+++ b/src/Service/OpenPlatform/SearchService.php
@@ -44,7 +44,6 @@ class SearchService
 
     private $searchCacheTTL;
     private $searchURL;
-    private $searchIndex;
     private $searchProfile;
 
     /**
@@ -72,7 +71,6 @@ class SearchService
         $this->client = $httpClient;
 
         $this->searchURL = $this->params->get('openPlatform.search.url');
-        $this->searchIndex = $this->params->get('openPlatform.search.index');
         $this->searchCacheTTL = (int) $this->params->get('openPlatform.search.ttl');
         $this->searchProfile = (string) $this->params->get('openPlatform.search.profile');
     }
@@ -258,11 +256,20 @@ class SearchService
      */
     private function recursiveSearch(string $token, string $identifier, string $type, int $offset = 0, array $results = []): array
     {
-        $query = $this->searchIndex.'='.$identifier;
-        if (IdentifierType::PID == $type) {
-            // If this is a search after a pid simply search for it and not in the search index.
-            $query = $identifier;
+        switch ($type) {
+            case IdentifierType::PID:
+                // If this is a search after a pid simply search for it and not in the search index.
+                $query = $identifier;
+                break;
+
+            case IdentifierType::ISBN:
+                $query = 'term.isbn='.$identifier;
+                break;
+
+            default:
+                $query = 'dkcclterm.is='.$identifier;
         }
+
         $response = $this->client->request('POST', $this->searchURL, [
             RequestOptions::JSON => [
                 'fields' => $this->fields,


### PR DESCRIPTION
This gives an more precise search when using ISBN and not an search in all fields that my have an ISBN. 

![Screenshot 2020-03-02 at 14 06 55](https://user-images.githubusercontent.com/111397/75679265-93532580-5c8f-11ea-8ea8-7d7dfbbee363.png)

It fixes the issue in https://platform.dandigbib.org/issues/4758

I have an plan for how to get service re-indexed and removed the "wrong" results.