### PR TITLE
Feature/bogportalen isbn fix

### DIFF
--- a/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
+++ b/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
@@ -28,7 +28,7 @@ class BogPortalenVendorService extends AbstractBaseVendorService
     use ProgressBarTrait;
 
     protected const VENDOR_ID = 1;
-    private const VENDOR_ARCHIVE_NAMES = ['BOP-ProductAll.zip', 'BOP-Actual-EXT.zip'];
+    private const VENDOR_ARCHIVE_NAMES = ['BOP-ProductAll.zip', 'BOP-ProductAll-EXT.zip', 'BOP-Actual.zip', 'BOP-Actual-EXT.zip'];
 
     private $local;
     private $ftp;
@@ -278,6 +278,8 @@ class BogPortalenVendorService extends AbstractBaseVendorService
             $temp = (string) $temp;
             if (($isbn === $temp) && (13 === strlen($isbn))) {
                 $isbnList[] = $isbn;
+            } else {
+                // @TODO: Should we log invalid ISBNs here?
             }
         }
 

--- a/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
+++ b/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
@@ -84,7 +84,7 @@ class BogPortalenVendorService extends AbstractBaseVendorService
                     $this->updateArchive($archive);
                 }
 
-                $this->progressMessage('Getting filenames from archive....');
+                $this->progressMessage('Getting filenames from archive: "'.$archive.'"');
                 $this->progressAdvance();
 
                 $localArchivePath = $this->local->getAdapter()->getPathPrefix().$archive;
@@ -259,18 +259,22 @@ class BogPortalenVendorService extends AbstractBaseVendorService
     }
 
     /**
-     * Get valid and unique ISBN numbers from list of filenames.
+     * Get valid and unique ISBN numbers from list of paths.
      *
-     * @param array $fileNames
+     * @param array $filePaths
      *
      * @return array
      */
-    private function getIsbnNumbers(array &$fileNames): array
+    private function getIsbnNumbers(array &$filePaths): array
     {
         $isbnList = [];
 
-        foreach ($fileNames as $fileName) {
-            $isbn = substr($fileName, -17, 13);
+        foreach ($filePaths as $filePath) {
+            // Example path: 'Archive/DBK-7003718/DBK-7003718-9788799933815.xml'
+            $pathParts = pathinfo($filePath);
+            $fileName = $pathParts['filename'];
+            $nameParts = explode('-', $fileName);
+            $isbn = array_pop($nameParts);
 
             // Ensure that the found string is a number to filter out
             // files with wrong or incomplete isbn numbers.


### PR DESCRIPTION
Have looked at the vendor. Can not see why this fails:

>Jeg kan ikke slå den op i Cover Service på hverken PID, FAUST, ISBN10 eller ISBN13.
> 
>Men jeg kan slå den op i Bogportalen – på ISBN13: http://images.bogportalen.dk/images/9788723972699.jpg
> 
>I BOP-ProductAll.zip under " \Archive\DBK-8000095\DBK-8000095-9788723972699.xml"

But have changed ISBN is extracted from the filename. Can see that a number of files lack valid ISBN13 numbers. Both in filename and in xml. Should we log this on import?

Also added all archives on the ftp-server to the import. Don't know if this makes a difference. I believe products are duplicated across archives. 