### PR TITLE
DDBTEAM-546: Added command to build elastic index template

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,9 @@ OPENPLATFORM_SEARCH_URL=https://openplatform.dbc.dk/v3/search
 OPENPLATFORM_SEARCH_TTL=86400
 OPENPLATFORM_SEARCH_PROFILE=allekilder
 
-ELASTIC_STATS_INDEX=stats_$(date +%d-%m-%Y)
+# Prefix used to match index template
+ELASTIC_STATS_INDEX_PREFIX=stats
+ELASTIC_STATS_INDEX=$(date +%d-%m-%Y)
 
 DATAWELL_VENDOR_AGENCY=775100
 DATAWELL_VENDOR_PROFILE=allekilder

--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ REDIS_CACHE_DSN=redis://redis:6379/11
 ###< enqueue/redis ###
 
 ###> ES ###
-ELASTIC_URL=http://elasticsearch:9200/
+ELASTIC_URL=http://elasticsearch:9200
 ###< ES ###
 
 ###> vendor ###

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ imports and images. These are mapped to and persisted in the database through
 doctrine. Further a 'search' entity is defined with the fields exposed by the
 REST API. This entity is mapped one-to-one to an index in ElasticSearch.
 
+### Logging and Statistics
+The application logs to ElasticSearch to allow debugging and monitoring. A 
+`stats_dd-mm-yyyy` is created daily. To ensure that Elastic chooses the right 
+type for the index fields a dynamic index template must be added to Elastic.
+This can be done with the `app:elastic:create-stats-template` command. 
+
 ## Implementation Overview
 
 ### Import/Index/Upload Engine

--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -1,7 +1,8 @@
 # Read the documentation: https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Resources/doc/setup.md
 fos_elastica:
     clients:
-        default: { url: '%env(ELASTIC_URL)%' }
+        # Note that Ruflin\Elastica requires a trailing slash
+        default: { url: '%env(ELASTIC_URL)%/' }
     indexes:
         app:
             index_name: app_%kernel.environment%

--- a/config/packages/monolog.yml
+++ b/config/packages/monolog.yml
@@ -15,5 +15,5 @@ monolog:
       type: elasticsearch
       elasticsearch:
         id: monolog.elastica.client
-      index: '%env(ELASTIC_STATS_INDEX)%'
+      index: '%env(ELASTIC_STATS_INDEX_PREFIX)%_%env(ELASTIC_STATS_INDEX)%'
       channels: ["statistics"]

--- a/config/packages/monolog.yml
+++ b/config/packages/monolog.yml
@@ -2,7 +2,8 @@ services:
   monolog.elastica.client:
     class: Elastica\Client
     arguments:
-      $config: { url: '%env(ELASTIC_URL)%' }
+      # Note that Ruflin\Elastica used by monolog requires a trailing slash
+      $config: { url: '%env(ELASTIC_URL)%/' }
 
 monolog:
   #

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,7 +18,6 @@ parameters:
     datawell.vendor.search_url: '%env(DATAWELL_VENDOR_SEARCH_URL)%'
     datawell.vendor.user: '%env(DATAWELL_VENDOR_USER)%'
     datawell.vendor.password: '%env(DATAWELL_VENDOR_PASSWORD)%'
-    elastic.url: '%env(ELASTIC_URL)%'
 
 services:
     # default configuration for services in *this* file
@@ -35,6 +34,8 @@ services:
             $cloudinaryUrl: '%env(CLOUDINARY_URL)%'
             $cloudinaryTransformations: '%env(yml:file:resolve:CLOUDINARY_CONFIG_FILE)%'
             $httpClient: '@eight_points_guzzle.client.guzzle_client'
+
+            $bindElasticSearchUrl: '%env(ELASTIC_URL)%'
 
     _instanceof:
         App\Service\VendorService\AbstractBaseVendorService:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,7 @@ services:
             $httpClient: '@eight_points_guzzle.client.guzzle_client'
 
             $bindElasticSearchUrl: '%env(ELASTIC_URL)%'
+            $bindElasticStatsIndexPrefix: '%env(ELASTIC_STATS_INDEX_PREFIX)%'
 
     _instanceof:
         App\Service\VendorService\AbstractBaseVendorService:

--- a/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
+++ b/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
@@ -19,6 +19,7 @@ class CreateDynamicStatsTemplateCommand extends Command
 {
     /* @var string $elasticHost */
     private $elasticHost;
+    private $elasticStatsIndexPrefix;
 
     protected static $defaultName = 'app:elastic:create-stats-template';
 
@@ -27,12 +28,15 @@ class CreateDynamicStatsTemplateCommand extends Command
      *
      * @param string $bindElasticSearchUrl
      *   The ElasticSearch endpoint url
+     * @param string $bindElasticStatsIndexPrefix
+     *   The prefix for statistics indices
      */
-    public function __construct(string $bindElasticSearchUrl)
+    public function __construct(string $bindElasticSearchUrl, string $bindElasticStatsIndexPrefix)
     {
         parent::__construct();
 
         $this->elasticHost = $bindElasticSearchUrl;
+        $this->elasticStatsIndexPrefix = $bindElasticStatsIndexPrefix;
     }
 
     /** {@inheritdoc} */
@@ -82,7 +86,7 @@ class CreateDynamicStatsTemplateCommand extends Command
             'name' => 'statistics_index_template',
             'body' => [
                 'index_patterns' => [
-                    'stats_*',
+                    $this->elasticStatsIndexPrefix.'*',
                 ],
                 'mappings' => [
                     'logs' => [

--- a/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
+++ b/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @file
+ * Command to create an dynamic index template elasticsearch.
+ */
+
+namespace App\Elastic\Command;
+
+use Elasticsearch\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class CreateDynamicStatsTemplateCommand.
+ */
+class CreateDynamicStatsTemplateCommand extends Command
+{
+    private $client;
+
+    protected static $defaultName = 'app:elastic:create-stats-template';
+
+    /**
+     * ElasticStatsTemplateCommand constructor.
+     *
+     * @param Client $client
+     *   ElasticSearch Client
+     */
+    public function __construct(Client $client)
+    {
+        parent::__construct();
+
+        $this->client = $client;
+    }
+
+    /** {@inheritdoc} */
+    protected function configure()
+    {
+        $this->setDescription('Create dynamic stats index template. Command is idempotent and can safely be called multiple times.');
+    }
+
+    /** {@inheritdoc} */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $result = $this->createStatsTemplate();
+
+            if ($result['acknowledged']) {
+                $io->success('Dynamic index template created.');
+
+                return 0;
+            }
+
+            $io->error('Unknown error when creating template');
+
+            return 1;
+        } catch (\Exception $exception) {
+            $io->error($exception->getMessage());
+
+            return 1;
+        }
+    }
+
+    /**
+     * Create a dynamic index template to ensure proper indexing in ElasticSearch.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-templates.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/dynamic-templates.html
+     *
+     * @return array
+     */
+    private function createStatsTemplate(): array
+    {
+        $params = [
+            'name' => 'statistics_index_template',
+            'body' => [
+                'index_patterns' => [
+                    'stats_*',
+                ],
+                'mappings' => [
+                    'logs' => [
+                        'dynamic_templates' => [
+                            [
+                                // Prevent ISBNs from being indexed as 'long'
+                                'identifier_as_keyword' => [
+                                    'match' => 'identifier',
+                                    'mapping' => [
+                                        'type' => 'keyword',
+                                    ],
+                                ],
+                            ], [
+                                // Prevent ISBNs from being indexed as 'long'
+                                'isIdentifier_as_keyword' => [
+                                    'match' => 'isIdentifier',
+                                    'mapping' => [
+                                        'type' => 'keyword',
+                                    ],
+                                ],
+                            ], [
+                                // Use proper ip-address type
+                                'remoteIP_as_ip' => [
+                                    'match' => 'remoteIP',
+                                    'mapping' => [
+                                        'type' => 'ip',
+                                    ],
+                                ],
+                            ], [
+                                // Always use 'keyword' for strings
+                                'strings_as_keyword' => [
+                                    'match_mapping_type' => 'string',
+                                    'mapping' => [
+                                        'type' => 'keyword',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            // Overwrite if template exists
+            'create' => false,
+        ];
+
+        return $this->client->indices()->putTemplate($params);
+    }
+}

--- a/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
+++ b/src/Command/Elastic/CreateDynamicStatsTemplateCommand.php
@@ -4,7 +4,7 @@
  * Command to create an dynamic index template elasticsearch.
  */
 
-namespace App\Elastic\Command;
+namespace App\Command\Elastic;
 
 use Elasticsearch\Client;
 use Symfony\Component\Console\Command\Command;

--- a/src/Service/PopulateService.php
+++ b/src/Service/PopulateService.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Elasticsearch\ClientBuilder;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * Class PopulateService.
@@ -38,16 +37,15 @@ class PopulateService
      *   The entity manager
      * @param SearchRepository $searchRepository
      *   The Search repository
-     * @param ParameterBagInterface $parameterBag
-     *   The parameter bag
+     * @param string $bindElasticSearchUrl
+     *   The ElasticSearch endpoint url
      */
-    public function __construct(EntityManagerInterface $entityManager, SearchRepository $searchRepository, ParameterBagInterface $parameterBag)
+    public function __construct(EntityManagerInterface $entityManager, SearchRepository $searchRepository, string $bindElasticSearchUrl)
     {
         $this->searchRepository = $searchRepository;
         $this->entityManager = $entityManager;
 
-        // @HACK to make the FOS elasticsearch URL work with elasticSearch library remove last '/'
-        $this->elasticHost = rtrim($parameterBag->get('elastic.url'), '/');
+        $this->elasticHost = $bindElasticSearchUrl;
 
         // Make sure that the sql logger is not enabled to avoid memory issues.
         $entityManager->getConnection()->getConfiguration()->setSQLLogger(null);


### PR DESCRIPTION
When an ISBN or faust is the first value written to the logs, the 'identifier' field is indexed at a 'long' (numeric). This prevents PID's from being written as values because Elastic does not allow for mixed types:

```
index: /stats_11-06-2020/logs/cWsco3IBsQau7qL5Lij2 caused failed to parse field
[context.identifier] of type [long] in document with id 'cWsco3IBsQau7qL5Lij2' 
``` 

This PR adds a command that adds a dynamic index template to elastic search. This ensures that `identifier` and `isIdentifier` fields are allways indexed as [keyword](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/keyword.html) regardless of their value.

Further 
- `remoteIP` are indexed as [ip](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/ip.html)
- All strings are indexed as [keyword](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/keyword.html)

See:
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/dynamic-templates.html
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-templates.html