### PR TITLE
DDBTEAM-666: Fix bogportalen import bug when no new archive found

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,6 +50,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php}}
+                  tools: composer:v1
                   extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
 
@@ -87,6 +88,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php}}
+                  tools: composer:v1
                   extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php}}
+                  tools: composer:v1
                   extensions: ctype, iconv, imagick, json, redis, soap, xmlreader, zip
                   coverage: none
 

--- a/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
+++ b/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
@@ -45,13 +45,8 @@ class BogPortalenVendorService extends AbstractBaseVendorService
      * @param loggerInterface $statsLogger
      *   Logger object to send stats to ES
      */
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        Filesystem $local,
-        Filesystem $ftp,
-        EntityManagerInterface $entityManager,
-        LoggerInterface $statsLogger
-    ) {
+    public function __construct(EventDispatcherInterface $eventDispatcher, Filesystem $local, Filesystem $ftp, EntityManagerInterface $entityManager, LoggerInterface $statsLogger)
+    {
         parent::__construct($eventDispatcher, $entityManager, $statsLogger);
 
         $this->local = $local;

--- a/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
+++ b/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
@@ -45,10 +45,13 @@ class BogPortalenVendorService extends AbstractBaseVendorService
      * @param loggerInterface $statsLogger
      *   Logger object to send stats to ES
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, Filesystem $local,
-                                Filesystem $ftp, EntityManagerInterface $entityManager,
-                                LoggerInterface $statsLogger)
-    {
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+        Filesystem $local,
+        Filesystem $ftp,
+        EntityManagerInterface $entityManager,
+        LoggerInterface $statsLogger
+    ) {
         parent::__construct($eventDispatcher, $entityManager, $statsLogger);
 
         $this->local = $local;


### PR DESCRIPTION
Fix for `File not found at path: BOP-ProductAll.zip` error. 

Previously we kept the downloaded archives. If a new import was started but no new archive was found, we skipped downloading the archive. But we still did a full read of the archive (again). Because we now delete the archives this fails if no new archive is found. 

Change logic to skip both download and read if there is no new archive.

Updated: Don't cache last modified timestamp for archives, instead always download and import