### PR TITLE
Command to fix missing images 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - '9300'
 
   rabbit:
-    image: rabbitmq:3-management
+    image: rabbitmq:3.8-management
     networks:
       - app
       - frontend

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,6 +23,11 @@
       <code>getCoverStoreURL</code>
     </PossiblyNullReference>
   </file>
+  <file src="src/Command/Image/MissingImagesCommand.php">
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>findById</code>
+    </PossiblyUndefinedMethod>
+  </file>
   <file src="src/Command/QueueInsertCommand.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>$vendorState ?? VendorState::INSERT</code>

--- a/src/Command/Image/MissingImagesCommand.php
+++ b/src/Command/Image/MissingImagesCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @file
+ * Console command to find images that are uploaded but not found in image table.
+ */
+
+namespace App\Command\Image;
+
+use App\Entity\Image;
+use App\Entity\Source;
+use App\Entity\Vendor;
+use App\Service\CoverStore\CoverStoreInterface;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class MissingImagesCommand.
+ */
+class MissingImagesCommand extends Command
+{
+    protected static $defaultName = 'app:image:missing';
+
+    private CoverStoreInterface $store;
+    private EntityManager $em;
+
+    /**
+     * MissingImagesCommand constructor.
+     *
+     * @param CoverStoreInterface $store
+     * @param EntityManager $entityManager
+     */
+    public function __construct(CoverStoreInterface $store, EntityManagerInterface $entityManager)
+    {
+        $this->store = $store;
+        $this->em = $entityManager;
+
+        parent::__construct();
+    }
+
+    /**
+     * Define the command.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setDescription('Find images in CoverStore that is not in the image table')
+            ->addOption('vendor-id', null, InputOption::VALUE_OPTIONAL, 'Limit the re-index to vendor with this id number')
+            ->addOption('identifier', null, InputOption::VALUE_OPTIONAL, 'If set only this identifier will be re-index (requires that you set vendor id)');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $vendorId = $input->getOption('vendor-id');
+        $identifier = $input->getOption('identifier');
+
+        $vendorRepos = $this->em->getRepository(Vendor::class);
+        $vendor = $vendorRepos->findById($vendorId);
+        if (is_null($vendor)) {
+            throw new \RuntimeException('Vendor not found');
+        }
+        $vendor = reset($vendor);
+
+        $query = 'SELECT s FROM App\Entity\Source s WHERE s.image IS NULL';
+        if (!is_null($identifier)) {
+            if (!is_null($vendorId)) {
+                $query .= ' AND s.matchId = \''.$identifier.'\'';
+            } else {
+                $output->writeln('<error>Missing vendor id required in combination with identifier</error>');
+
+                return 1;
+            }
+        }
+        if (!is_null($vendorId)) {
+            $query .= ' AND s.vendor = '.$vendorId;
+        }
+
+        $query = $this->em->createQuery($query);
+        $iterableResult = $query->iterate();
+        foreach ($iterableResult as $row) {
+            /* @var Source $source */
+            $source = $row[0];
+
+            // Ensure that ':' is escaped in the search query.
+            $id = 'public_id:'.$vendor->getName().'/'.str_replace(':', '\:', $source->getMatchId());
+            $items = $this->store->search($vendor->getName(), $id);
+            if (!empty($items)) {
+                $item = reset($items);
+                $image = new Image();
+                $image->setImageFormat($item->getImageFormat())
+                    ->setSize($item->getSize())
+                    ->setWidth($item->getWidth())
+                    ->setHeight($item->getHeight())
+                    ->setCoverStoreURL($item->getUrl());
+                $this->em->persist($image);
+                $source->setImage($image);
+                $this->em->flush();
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/QueueInsertCommand.php
+++ b/src/Command/QueueInsertCommand.php
@@ -71,7 +71,7 @@ class QueueInsertCommand extends Command
                     $message->setIdentifierType(IdentifierType::PID);
                     $message->setIdentifier('1234567890');
                     $message->setVendorId('15');
-                    $message->setImageUrl('https://www.danskernesdigitalebibliotek.dk/fileadmin/_kulturstyrelsen/images/ddb/logo.png');
+                    $message->setImageUrl('https://images.bogportalen.dk/images/9788740050134.jpg');
                     $message->setOperation($vendorState ?? VendorState::INSERT);
                     break;
 

--- a/src/Command/Source/SourceUpdateImageMetaCommand.php
+++ b/src/Command/Source/SourceUpdateImageMetaCommand.php
@@ -36,7 +36,7 @@ class SourceUpdateImageMetaCommand extends Command
      */
     protected function configure()
     {
-        $this->setDescription('Update image metadata informations')
+        $this->setDescription('Update image metadata information')
             ->addOption('identifier', null, InputOption::VALUE_OPTIONAL, 'Only for this identifier');
     }
 

--- a/src/Service/CoverStore/CloudinaryCoverStoreService.php
+++ b/src/Service/CoverStore/CloudinaryCoverStoreService.php
@@ -124,7 +124,7 @@ class CloudinaryCoverStoreService implements CoverStoreInterface
             ->max_results(100);
 
         if (!is_null($rawQuery)) {
-            $search->expression($rawQuery.' and folder='.$folder);
+            $search->expression($rawQuery);
         }
         $result = $search->execute()->getArrayCopy();
 

--- a/src/Service/VendorService/VendorImageValidatorService.php
+++ b/src/Service/VendorService/VendorImageValidatorService.php
@@ -5,7 +5,6 @@ namespace App\Service\VendorService;
 use App\Entity\Source;
 use App\Utils\CoverVendor\VendorImageItem;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 
 /**
@@ -29,8 +28,6 @@ class VendorImageValidatorService
      * Validate that remote image exists by sending a HTTP HEAD request.
      *
      * @param VendorImageItem $item
-     *
-     * @throws GuzzleException
      */
     public function validateRemoteImage(VendorImageItem $item): void
     {
@@ -58,7 +55,7 @@ class VendorImageValidatorService
             // Some images exists (return 200) but have no content
             $found = $item->getOriginalContentLength() > 0;
             $item->setFound($found);
-        } catch (ClientException $exception) {
+        } catch (\Throwable $e) {
             $item->setFound(false);
         }
     }


### PR DESCRIPTION
A missing database migration has resultet in images uploaded to CoverStore but not indexed in the database. This PR adds a new command to find this an fix the database.