### PR TITLE
DDBTEAM-949: Changed ES to use index alias

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -5,7 +5,8 @@ fos_elastica:
         default: { url: '%env(ELASTIC_URL)%/' }
     indexes:
         app:
-            index_name: app_%kernel.environment%
+            index_name: coverservice
+            use_alias: true
             types:
                 search:
                     properties:

--- a/src/Command/SearchPopulateCommand.php
+++ b/src/Command/SearchPopulateCommand.php
@@ -40,7 +40,6 @@ class SearchPopulateCommand extends Command
     {
         $this
             ->setDescription('Populate the search index with data from the search table.')
-            ->addOption('index', null, InputOption::VALUE_REQUIRED, 'The index to populate.')
             ->addOption('id', null, InputOption::VALUE_OPTIONAL, 'Single search table record id (try populate single record)', -1);
     }
 
@@ -49,18 +48,13 @@ class SearchPopulateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $index = (string) $input->getOption('index');
         $id = (int) $input->getOption('id');
-
-        if (!$index) {
-            throw new \RuntimeException('Index must be specified.');
-        }
 
         $progressBar = new ProgressBar($output);
         $progressBar->setFormat('[%bar%] %elapsed% (%memory%) - %message%');
 
         $this->populateService->setProgressBar($progressBar);
-        $this->populateService->populate($index, $id);
+        $this->populateService->populate($id);
 
         // Start the command line on a new line.
         $output->writeln('');

--- a/src/Service/PopulateService.php
+++ b/src/Service/PopulateService.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Elasticsearch\ClientBuilder;
+use FOS\ElasticaBundle\Exception\AliasIsIndexException;
 use FOS\ElasticaBundle\Index\IndexManager;
 use FOS\ElasticaBundle\Index\Resetter;
 
@@ -147,7 +148,13 @@ class PopulateService
             $index->refresh();
 
             $this->progressMessage(sprintf('<info>Switching alias</info> <comment>%s -> %s</comment>', $index->getOriginalName(), $index->getName()));
-            $this->resetter->switchIndexAlias($indexName, true);
+
+            // Switching the alias and deleting the old index.
+            try {
+                $this->resetter->switchIndexAlias($indexName, true);
+            } catch (AliasIsIndexException $exception) {
+                $this->progressMessage('<info>Failed to switch alias, please to it by hand</info>');
+            }
         }
 
         $this->progressFinish();

--- a/src/Service/PopulateService.php
+++ b/src/Service/PopulateService.php
@@ -16,6 +16,8 @@ use Elasticsearch\ClientBuilder;
 use FOS\ElasticaBundle\Exception\AliasIsIndexException;
 use FOS\ElasticaBundle\Index\IndexManager;
 use FOS\ElasticaBundle\Index\Resetter;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 
 /**
  * Class PopulateService.
@@ -31,18 +33,20 @@ class PopulateService
     private EntityManagerInterface $entityManager;
     private IndexManager $indexManager;
     private Resetter $resetter;
+    private LockFactory $lockFactory;
+    private LockInterface $lock;
 
     /**
      * PopulateService constructor.
      *
      * @param EntityManagerInterface $entityManager
-     *   The entity manager
      * @param SearchRepository $searchRepository
-     *   The Search repository
+     * @param IndexManager $indexManager
+     * @param Resetter $resetter
+     * @param LockFactory $lockFactory
      * @param string $bindElasticSearchUrl
-     *   The ElasticSearch endpoint url
      */
-    public function __construct(EntityManagerInterface $entityManager, SearchRepository $searchRepository, IndexManager $indexManager, Resetter $resetter, string $bindElasticSearchUrl)
+    public function __construct(EntityManagerInterface $entityManager, SearchRepository $searchRepository, IndexManager $indexManager, Resetter $resetter, LockFactory $lockFactory, string $bindElasticSearchUrl)
     {
         $this->searchRepository = $searchRepository;
         $this->entityManager = $entityManager;
@@ -50,6 +54,7 @@ class PopulateService
         $this->elasticHost = $bindElasticSearchUrl;
         $this->indexManager = $indexManager;
         $this->resetter = $resetter;
+        $this->lockFactory = $lockFactory;
     }
 
     /**
@@ -57,106 +62,144 @@ class PopulateService
      *
      * @param int $record_id
      *   Limit populate to this single search record id
+     * @param bool $force
+     *   Force execution ignoring locks (default false)
      *
      * @throws NoResultException
      * @throws NonUniqueResultException
      *
      * @return void
      */
-    public function populate(int $record_id = -1): void
+    public function populate(int $record_id = -1, bool $force = false): void
     {
         $this->progressStart('Starting populate process');
 
-        $client = ClientBuilder::create()->setHosts([$this->elasticHost])->build();
+        if ($this->acquireLock($force)) {
+            $client = ClientBuilder::create()->setHosts([$this->elasticHost])->build();
+            $indexes = array_keys($this->indexManager->getAllIndexes());
+            foreach ($indexes as $indexName) {
+                // When aliases is configured this reset will create a new index in ES.
+                $this->resetter->resetIndex($indexName, true);
 
-        $indexes = array_keys($this->indexManager->getAllIndexes());
-        foreach ($indexes as $indexName) {
-            // When aliases is configured this reset will create a new index in ES.
-            $this->resetter->resetIndex($indexName, true);
+                // Get information about the newly created index and get its name.
+                $index = $this->indexManager->getIndex($indexName);
 
-            // Get information about the newly created index and get its name.
-            $index = $this->indexManager->getIndex($indexName);
-
-            $numberOfRecords = 1;
-            $lastId = $record_id;
-            if (-1 === $record_id) {
-                $numberOfRecords = $this->searchRepository->getNumberOfRecords();
-                $lastId = $this->searchRepository->findLastId();
-            }
-            // Make sure there are entries in the Search table to process.
-            if (0 === $numberOfRecords || null === $lastId) {
-                $this->progressMessage('No entries in Search table.');
-                $this->progressFinish();
-
-                return;
-            }
-
-            $entriesAdded = 0;
-            $currentId = 0;
-
-            while ($entriesAdded < $numberOfRecords) {
-                $params = ['body' => []];
-
-                $criteria = [];
-                if (-1 !== $record_id) {
-                    $criteria = ['id' => $record_id];
+                $numberOfRecords = 1;
+                $lastId = $record_id;
+                if (-1 === $record_id) {
+                    $numberOfRecords = $this->searchRepository->getNumberOfRecords();
+                    $lastId = $this->searchRepository->findLastId();
                 }
-                $entities = $this->searchRepository->findBy($criteria, ['id' => 'ASC'], self::BATCH_SIZE, $entriesAdded);
+                // Make sure there are entries in the Search table to process.
+                if (0 === $numberOfRecords || null === $lastId) {
+                    $this->progressMessage('No entries in Search table.');
+                    $this->progressFinish();
 
-                // No more results.
-                if (0 === count($entities)) {
-                    $this->progressMessage(sprintf('%d of %d processed. Id: %d. Last id: %d. No more results.', $entriesAdded, $numberOfRecords, $currentId, $lastId));
-                    break;
+                    return;
                 }
 
-                foreach ($entities as $entity) {
-                    $params['body'][] = [
-                        'index' => [
-                            '_index' => $index->getName(),
-                            '_id' => $entity->getId(),
-                            '_type' => 'search',
-                        ],
-                    ];
+                $entriesAdded = 0;
+                $currentId = 0;
 
-                    $params['body'][] = [
-                        'isIdentifier' => $entity->getIsIdentifier(),
-                        'isType' => $entity->getIsType(),
-                        'imageUrl' => $entity->getImageUrl(),
-                        'imageFormat' => $entity->getImageFormat(),
-                        'width' => $entity->getWidth(),
-                        'height' => $entity->getHeight(),
-                    ];
+                while ($entriesAdded < $numberOfRecords) {
+                    $params = ['body' => []];
 
-                    ++$entriesAdded;
-                    $currentId = $entity->getId();
+                    $criteria = [];
+                    if (-1 !== $record_id) {
+                        $criteria = ['id' => $record_id];
+                    }
+                    $entities = $this->searchRepository->findBy($criteria, ['id' => 'ASC'], self::BATCH_SIZE, $entriesAdded);
+
+                    // No more results.
+                    if (0 === count($entities)) {
+                        $this->progressMessage(sprintf('%d of %d processed. Id: %d. Last id: %d. No more results.', $entriesAdded, $numberOfRecords, $currentId, $lastId));
+                        break;
+                    }
+
+                    foreach ($entities as $entity) {
+                        $params['body'][] = [
+                            'index' => [
+                                '_index' => $index->getName(),
+                                '_id' => $entity->getId(),
+                                '_type' => 'search',
+                            ],
+                        ];
+
+                        $params['body'][] = [
+                            'isIdentifier' => $entity->getIsIdentifier(),
+                            'isType' => $entity->getIsType(),
+                            'imageUrl' => $entity->getImageUrl(),
+                            'imageFormat' => $entity->getImageFormat(),
+                            'width' => $entity->getWidth(),
+                            'height' => $entity->getHeight(),
+                        ];
+
+                        ++$entriesAdded;
+                        $currentId = $entity->getId();
+                    }
+
+                    // Send bulk.
+                    $client->bulk($params);
+
+                    // Update progress message.
+                    $this->progressMessage(sprintf('%d of %d added. Id: %d. Last id: %d.', $entriesAdded, $numberOfRecords, $currentId, $lastId));
+
+                    // Free up memory usages.
+                    $this->entityManager->clear();
+                    gc_collect_cycles();
+
+                    $this->progressAdvance();
                 }
 
-                // Send bulk.
-                $client->bulk($params);
+                $this->progressMessage(sprintf('<info>Refreshing</info> <comment>%s</comment>', $index->getName()));
+                $index->refresh();
 
-                // Update progress message.
-                $this->progressMessage(sprintf('%d of %d added. Id: %d. Last id: %d.', $entriesAdded, $numberOfRecords, $currentId, $lastId));
+                $this->progressMessage(sprintf('<info>Switching alias</info> <comment>%s -> %s</comment>', $index->getOriginalName(), $index->getName()));
 
-                // Free up memory usages.
-                $this->entityManager->clear();
-                gc_collect_cycles();
-
-                $this->progressAdvance();
+                // Switching the alias and deleting the old index.
+                try {
+                    $this->resetter->switchIndexAlias($indexName, true);
+                } catch (AliasIsIndexException $exception) {
+                    $this->progressMessage('<info>Failed to switch alias, please to it by hand</info>');
+                }
             }
 
-            $this->progressMessage(sprintf('<info>Refreshing</info> <comment>%s</comment>', $index->getName()));
-            $index->refresh();
-
-            $this->progressMessage(sprintf('<info>Switching alias</info> <comment>%s -> %s</comment>', $index->getOriginalName(), $index->getName()));
-
-            // Switching the alias and deleting the old index.
-            try {
-                $this->resetter->switchIndexAlias($indexName, true);
-            } catch (AliasIsIndexException $exception) {
-                $this->progressMessage('<info>Failed to switch alias, please to it by hand</info>');
-            }
+            $this->releaseLock();
+        } else {
+            $this->progressMessage('<error>Process is already running use "--force" to run command</error>');
         }
 
         $this->progressFinish();
+    }
+
+    /**
+     * Get process lock.
+     *
+     * Used to prevent more than one populating process running at once.
+     *
+     * @param bool $force
+     *  Force execution ignoring locks (default false)
+     *
+     * @return bool
+     *   If lock acquired true else false
+     */
+    private function acquireLock(bool $force = false): bool
+    {
+        // Get lock with an TTL of 1 hour, which should be more than enough to populate ES.
+        $this->lock = $this->lockFactory->createLock('app:search:populate:lock', 3600, false);
+
+        if ($this->lock->acquire() || $force) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Release the populating process lock.
+     */
+    private function releaseLock(): void
+    {
+        $this->lock->release();
     }
 }


### PR DESCRIPTION
Added support for ES index alias in the populate service to enabled indexing without down time.


Requires: https://github.com/danskernesdigitalebibliotek/ddb-cover-service/pull/133