### PR TITLE
SUPPORT-438: Ensured properties are initilized in messages

### DIFF
--- a/src/Message/AbstractBaseMessage.php
+++ b/src/Message/AbstractBaseMessage.php
@@ -15,9 +15,9 @@ abstract class AbstractBaseMessage
     private string $identifierType;
     private string $identifier;
     private int $vendorId;
-    private ?int $imageId;
+    private ?int $imageId = null;
     private bool $useSearchCache = true;
-    private string $traceId;
+    private ?string $traceId = null;
 
     /**
      * @return string


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/SUPP0RT-438

#### Description

Strong types are blocking for cover imports.

* Typed property App\Message\AbstractBaseMessage::$imageId must not be accessed before initialization.

#### Screenshot of the result

No screenshots.

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

No comments.
