### PR TITLE
Feature/ddbteam 1051 the moviedatabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 ### Changed
 - Deprecated "datawell" vendor (now "ComicsPlus" vendor).
 - TheMovieDatabaseVendor has been refactored to use the Abstract DatawellVendor.
+- TheMovieDatabaseVendor now supports single cover no hits processing. 
+- Match logic for TheMovieDatabaseVendor has been refactored for better matching.
+- VendorServiceSingleIdentifierInterface now has nullable return.
 - OverDriveMagazinesVendorService has been refactored to use the Abstract DatawellVendor.
 - PressReaderVendorService has been refactored to use the Abstract DatawellVendor.
 - Consolidated all datawell search code to a DataWellClient;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 ### Changed
 - Deprecated "datawell" vendor (now "ComicsPlus" vendor).
 - TheMovieDatabaseVendor has been refactored to use the Abstract DatawellVendor.
-- TheMovieDatabaseVendor now supports single cover no hits processing. 
+- TheMovieDatabaseVendor now supports single cover no hits processing.
 - Match logic for TheMovieDatabaseVendor has been refactored for better matching.
 - VendorServiceSingleIdentifierInterface now has nullable return.
 - OverDriveMagazinesVendorService has been refactored to use the Abstract DatawellVendor.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "itk-dev/metrics-bundle": "^1.0.0",
         "league/oauth2-client": "^2.6",
         "nicebooks/isbn": "^0.3",
+        "oefenweb/damerau-levenshtein": "^3.0",
         "predis/predis": "^2.0",
+        "prinsfrank/standards": "^1.3",
         "scriptotek/marc": "^2.1",
         "symfony/amqp-messenger": "^6.1",
         "symfony/cache": "^6.1",
@@ -42,13 +44,15 @@
         "symfony/process": "^6.1",
         "symfony/runtime": "^6.1",
         "symfony/serializer": "^6.1",
-        "symfony/yaml": "^6.1"
+        "symfony/yaml": "^6.1",
+        "thecodingmachine/safe": "^2.3"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "escapestudios/symfony2-coding-standard": "^3.10",
         "fakerphp/faker": "^1.14",
         "friendsofphp/php-cs-fixer": "^3.8",
+        "hectorj/safe-php-psalm-plugin": "^1.4",
         "jetbrains/phpstorm-attributes": "^1.0",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.11",
         "phpunit/phpunit": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed9585b1355b180a86a11259024b1c1a",
+    "content-hash": "cac27264cd53fddc54772ccbafcc0ebc",
     "packages": [
         {
             "name": "box/spout",
@@ -2528,6 +2528,65 @@
             "time": "2022-08-01T20:46:23+00:00"
         },
         {
+            "name": "oefenweb/damerau-levenshtein",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Oefenweb/damerau-levenshtein.git",
+                "reference": "3f63a83b647fd24c3822b7cff0cde6ae3d25cff9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Oefenweb/damerau-levenshtein/zipball/3f63a83b647fd24c3822b7cff0cde6ae3d25cff9",
+                "reference": "3f63a83b647fd24c3822b7cff0cde6ae3d25cff9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "oefenweb/cakephp-codesniffer": "^2.0",
+                "phpmd/phpmd": "^2.0",
+                "phpstan/phpstan": "^0.12.66",
+                "phpunit/phpunit": "^7.5",
+                "sebastian/phpcpd": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Oefenweb\\DamerauLevenshtein\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ph4r05",
+                    "homepage": "http://www.phpclasses.org/package/7021-PHP-Get-text-similarity-level-with-Damerau-Levenshtein.html"
+                },
+                {
+                    "name": "Oefenweb.nl BV team",
+                    "homepage": "https://github.com/Oefenweb/damerau-levenshtein/contributors"
+                }
+            ],
+            "description": "Get text similarity level with Damerau-Levenshtein distance",
+            "homepage": "http://github.com/Oefenweb/damerau-levenshtein",
+            "keywords": [
+                "damerau",
+                "distance",
+                "levenshtein",
+                "similarity"
+            ],
+            "support": {
+                "issues": "https://github.com/Oefenweb/damerau-levenshtein/issues",
+                "source": "https://github.com/Oefenweb/damerau-levenshtein"
+            },
+            "time": "2022-03-23T10:44:48+00:00"
+        },
+        {
             "name": "pear/file_marc",
             "version": "1.4.1",
             "source": {
@@ -2898,6 +2957,51 @@
                 }
             ],
             "time": "2022-06-08T13:14:56+00:00"
+        },
+        {
+            "name": "prinsfrank/standards",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrinsFrank/standards.git",
+                "reference": "9b352fcfd0ac51e5484858a59603c89c13446cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrinsFrank/standards/zipball/9b352fcfd0ac51e5484858a59603c89c13446cce",
+                "reference": "9b352fcfd0ac51e5484858a59603c89c13446cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "composer/composer": "^2.3",
+                "dbrekelmans/bdi": "^1.0",
+                "ext-dom": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "friendsofphp/php-cs-fixer": "^3.8",
+                "phpstan/phpstan": "^1.8",
+                "phpunit/phpunit": "^9.5",
+                "symfony/panther": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrinsFrank\\Standards\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A collection of standards as PHP Enums: ISO3166, ISO4217, ISO639...",
+            "support": {
+                "issues": "https://github.com/PrinsFrank/standards/issues",
+                "source": "https://github.com/PrinsFrank/standards/tree/v1.3.0"
+            },
+            "time": "2022-08-24T20:01:35+00:00"
         },
         {
             "name": "promphp/prometheus_client_php",
@@ -6807,6 +6911,144 @@
                 "source": "https://github.com/teapot-php/status-code/tree/v1.1.2"
             },
             "time": "2020-11-03T17:14:32+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "dc8df8f5047e7d3021a3f41f492dc99f8b3dc475"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/dc8df8f5047e7d3021a3f41f492dc99f8b3dc475",
+                "reference": "dc8df8f5047e7d3021a3f41f492dc99f8b3dc475",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "deprecated/apc.php",
+                    "deprecated/array.php",
+                    "deprecated/datetime.php",
+                    "deprecated/libevent.php",
+                    "deprecated/password.php",
+                    "deprecated/mssql.php",
+                    "deprecated/stats.php",
+                    "deprecated/strings.php",
+                    "lib/special_cases.php",
+                    "deprecated/mysqli.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "deprecated/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v2.3.0"
+            },
+            "time": "2022-09-13T15:49:48+00:00"
         }
     ],
     "packages-dev": [
@@ -7782,6 +8024,59 @@
                 }
             ],
             "time": "2022-07-22T08:43:51+00:00"
+        },
+        {
+            "name": "hectorj/safe-php-psalm-plugin",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hectorj/safe-php-psalm-plugin.git",
+                "reference": "a08fa3152f72d4522bfa8d9612e987ecff2f80a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hectorj/safe-php-psalm-plugin/zipball/a08fa3152f72d4522bfa8d9612e987ecff2f80a1",
+                "reference": "a08fa3152f72d4522bfa8d9612e987ecff2f80a1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.4 || ^8.0",
+                "thecodingmachine/safe": "^1.1|^2.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "HectorJ\\SafePHPPsalmPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "HectorJ\\SafePHPPsalmPlugin\\": [
+                        "./src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "hectorj"
+                }
+            ],
+            "description": "vimeo/psalm plugin for thecodingmachine/safe",
+            "support": {
+                "issues": "https://github.com/hectorj/safe-php-psalm-plugin/issues",
+                "source": "https://github.com/hectorj/safe-php-psalm-plugin/tree/v1.4.0"
+            },
+            "time": "2022-05-21T19:45:24+00:00"
         },
         {
             "name": "jetbrains/phpstorm-attributes",

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,14 +13,6 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-    <issueHandlers>
-        <PossiblyNullIterator>
-            <errorLevel type="suppress">
-                <file name="src/Service/DataWell/DataWellClient.php"/>
-                <file name="src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php"/>
-            </errorLevel>
-        </PossiblyNullIterator>
-    </issueHandlers>
     <plugins>
         <pluginClass class="HectorJ\SafePHPPsalmPlugin\Plugin"/>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,6 +22,7 @@
         </PossiblyNullIterator>
     </issueHandlers>
     <plugins>
+        <pluginClass class="HectorJ\SafePHPPsalmPlugin\Plugin"/>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
             <containerXml>var/cache/dev/App_KernelDevDebugContainer.xml</containerXml>
         </pluginClass>

--- a/src/MessageHandler/SearchNoHitsMessageHandler.php
+++ b/src/MessageHandler/SearchNoHitsMessageHandler.php
@@ -143,7 +143,10 @@ class SearchNoHitsMessageHandler implements MessageHandlerInterface
             /** @var VendorServiceSingleIdentifierInterface $vendor */
             foreach ($this->singleIdentifierVendors as $vendor) {
                 if ($vendor->supportsIdentifierType($identifier->getType())) {
-                    $items[] = $vendor->getUnverifiedVendorImageItem($identifier->getId(), $identifier->getType());
+                    $item = $vendor->getUnverifiedVendorImageItem($identifier->getId(), $identifier->getType());
+                    if (null !== $item) {
+                        $items[] = $item;
+                    }
                 }
             }
         }

--- a/src/Service/DataWell/DataWellClient.php
+++ b/src/Service/DataWell/DataWellClient.php
@@ -108,11 +108,11 @@ class DataWellClient
 
         if (isset($jsonContent->searchResponse?->result?->searchResult)) {
             foreach ($jsonContent->searchResponse->result->searchResult as $searchResult) {
-                foreach ($searchResult->collection?->object as $object) {
+                foreach ($searchResult->collection?->object ?? [] as $object) {
                     $pid = $object->identifier?->{'$'};
                     if (null !== $pid) {
                         $data[$pid] = null;
-                        foreach ($object->relations?->relation as $relation) {
+                        foreach ($object->relations?->relation ?? [] as $relation) {
                             if ($coverUrlRelationKey === $relation->relationType?->{'$'}) {
                                 $coverUrl = $relation->relationUri?->{'$'};
                                 $data[$pid] = (string) $coverUrl;
@@ -140,8 +140,8 @@ class DataWellClient
         $data = [];
 
         if (isset($jsonContent->searchResponse?->result?->searchResult)) {
-            foreach ($jsonContent->searchResponse?->result?->searchResult as $searchResult) {
-                foreach ($searchResult->collection?->object as $object) {
+            foreach ($jsonContent->searchResponse?->result?->searchResult ?? [] as $searchResult) {
+                foreach ($searchResult->collection?->object ?? [] as $object) {
                     $pid = $object->identifier?->{'$'};
                     if (null !== $pid) {
                         $data[$pid] = $object;

--- a/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
+++ b/src/Service/VendorService/BogPortalen/BogPortalenVendorService.php
@@ -120,7 +120,7 @@ class BogPortalenVendorService implements VendorServiceImporterInterface, Vendor
     /**
      * {@inheritDoc}
      */
-    public function getUnverifiedVendorImageItem(string $identifier, string $type): UnverifiedVendorImageItem
+    public function getUnverifiedVendorImageItem(string $identifier, string $type): ?UnverifiedVendorImageItem
     {
         if (!$this->supportsIdentifierType($type)) {
             throw new UnsupportedIdentifierTypeException('Unsupported single identifier type: '.$type);

--- a/src/Service/VendorService/OpenLibrary/OpenLibraryVendor.php
+++ b/src/Service/VendorService/OpenLibrary/OpenLibraryVendor.php
@@ -24,7 +24,7 @@ class OpenLibraryVendor implements VendorServiceSingleIdentifierInterface
     /**
      * {@inheritDoc}
      */
-    public function getUnverifiedVendorImageItem(string $identifier, string $type): UnverifiedVendorImageItem
+    public function getUnverifiedVendorImageItem(string $identifier, string $type): ?UnverifiedVendorImageItem
     {
         if (!$this->supportsIdentifierType($type)) {
             throw new UnsupportedIdentifierTypeException('Unsupported single identifier type: '.$type);

--- a/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseApiClient.php
+++ b/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseApiClient.php
@@ -7,8 +7,11 @@
 
 namespace App\Service\VendorService\TheMovieDatabase;
 
+use Oefenweb\DamerauLevenshtein\DamerauLevenshtein;
 use Psr\Log\LoggerInterface;
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -35,48 +38,114 @@ class TheMovieDatabaseApiClient
     }
 
     /**
-     * Search in the movie database for a poster url by title, year and director.
+     * Search in the movie database for a poster url by title, possible years and director.
      *
      * @param string|null $title
      *   The title of the item
-     * @param string|null $originalYear
-     *   The release year of the item
-     * @param string|null $director
-     *   The director of the movie
+     * @param string $originalTitle
+     *   The original title of the item
+     * @param array $originalYears
+     *   Array of possible release years for the item
+     * @param array $creators
+     *   The creators of the movie
+     * @param string $language
+     *   The language of the movie
      *
      * @return string|null
      *   The poster url or null
      */
-    public function searchPosterUrl(?string $title = null, ?string $originalYear = null, ?string $director = null): ?string
-    {
-        $posterUrl = null;
-
+    public function searchPosterUrl(
+        ?string $title,
+        string $originalTitle,
+        array $originalYears,
+        array $creators,
+        string $language
+    ): ?string {
         // Bail out if the required information is not supplied.
-        if (null === $title || null === $originalYear || null === $director) {
+        if (null === $title || empty($originalYears) || empty($creators)) {
             return null;
         }
 
+        // Search for the given years. TMDB does not support searching by range of release years.
+        foreach ($originalYears as $originalYear) {
+            $posterUrl = $this->searchPosterUrlByYear($title, $originalTitle, $originalYear, $creators, $language);
+            if (null !== $posterUrl) {
+                return $posterUrl;
+            }
+        }
+
+        // Try the search again but for "originalTitle"
+        if ('' !== $originalTitle) {
+            foreach ($originalYears as $originalYear) {
+                $posterUrl = $this->searchPosterUrlByYear(
+                    $originalTitle,
+                    $originalTitle,
+                    $originalYear,
+                    $creators,
+                    $language
+                );
+                if (null !== $posterUrl) {
+                    return $posterUrl;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Search in the movie database for a poster url by title, specific year and director.
+     *
+     * @param string $title
+     *   The title of the item
+     * @param string $originalTitle
+     *   The original title of the item
+     * @param int $originalYear
+     *   The release year of the item
+     * @param array $creators
+     *   The creators of the movie
+     * @param string $language
+     *   The language of the movie
+     *
+     * @return string|null
+     *   The poster url or null
+     */
+    private function searchPosterUrlByYear(
+        string $title,
+        string $originalTitle,
+        int $originalYear,
+        array $creators,
+        string $language
+    ): ?string {
+        $posterUrl = null;
+
+        // @see https://developers.themoviedb.org/3/movies/get-movie-images
         $query = [
             'query' => [
                 'query' => $title,
                 'year' => $originalYear,
                 'api_key' => $this->apiKey,
+                'language' => $language,
+                'include_image_language' => 'en,null',
                 'page' => '1',
                 'include_adult' => 'false',
-                'language' => 'da_DK',
             ],
         ];
 
         try {
             $responseData = $this->sendRequest(self::SEARCH_URL, $query);
 
-            $result = $this->getResultFromSet($responseData->results, $title, $director);
+            $result = $this->getResultFromSet($responseData->results, $title, $originalTitle, $creators);
 
             if ($result) {
                 $posterUrl = $this->getPosterUrl($result);
             }
-        } catch (\Exception|TransportExceptionInterface) {
+        } catch (\Exception) {
             // Catch all exceptions to avoid crashing.
+        }
+
+        if (null === $posterUrl) {
+            $d = 1;
         }
 
         return $posterUrl;
@@ -85,56 +154,183 @@ class TheMovieDatabaseApiClient
     /**
      * Get the first match in the result set.
      *
-     * @param array $results
-     *   Array of search results
-     * @param string $title
-     *   The title of the item
-     * @param string $director
-     *   The director of the item
+     * @param array $tmdbResults
+     *   Array of searxch results from The Movie Database (TMDB)
+     * @param string $dwTitle
+     *   The datawell title of the item
+     * @param string|null $dwOriginalTitle
+     *   The datawell original title of the item
+     * @param array $dwCreators
+     *   The datawell creators of the item
      *
      * @return \stdClass|null
      *   The matching result or null
      */
-    private function getResultFromSet(array $results, string $title, string $director): ?\stdClass
+    private function getResultFromSet(array $tmdbResults, string $dwTitle, ?string $dwOriginalTitle, array $dwCreators): ?\stdClass
     {
-        $lowercaseResultTitle = mb_strtolower($title, 'UTF-8');
-        $lowercaseDirector = mb_strtolower($director, 'UTF-8');
+        $dwOriginalTitle = $dwOriginalTitle ?? '';
 
-        $chosenResult = null;
-
-        foreach ($results as $result) {
+        foreach ($tmdbResults as $tmdbResult) {
             // Validate title against result->title or result->original_title.
-            if (mb_strtolower((string) $result->title, 'UTF-8') === $lowercaseResultTitle || mb_strtolower((string) $result->original_title, 'UTF-8') === $lowercaseResultTitle) {
-                // Validate director.
-                // https://developers.themoviedb.org/3/movies/get-movie-credits
-                $queryUrl = 'https://api.themoviedb.org/3/movie/'.$result->id.'/credits';
-                $responseData = $this->sendRequest($queryUrl);
-
-                $directors = array_reduce($responseData->crew, function ($carry, $item) {
-                    if ('Director' === $item->job) {
-                        $carry[] = mb_strtolower((string) $item->name, 'UTF-8');
-                    }
-
-                    return $carry;
-                }, []);
-
-                if (in_array($lowercaseDirector, $directors)) {
-                    // If more than one director, bail out.
-                    if (null !== $chosenResult) {
-                        return null;
-                    }
-                    $chosenResult = $result;
+            // Minimum length of 3 for title contain check is risky - Think "The..."
+            // We back it up by validating creators.
+            if ($this->getTitlesHasMatch($tmdbResult->title, $tmdbResult->original_title, $dwTitle, $dwOriginalTitle, 0.8, 3)) {
+                if ($this->validateCreators($tmdbResult->id, $dwCreators)) {
+                    return $tmdbResult;
                 }
             }
         }
 
-        return $chosenResult;
+        return null;
+    }
+
+    /**
+     * Validate Datawell creators are found in the TMDB crew list.
+     *
+     * @see https://developers.themoviedb.org/3/movies/get-movie-credits
+     *
+     * @param int $tmdbId
+     * @param array $dwCreators
+     * @param float $relativeDistance
+     *
+     * @return bool
+     */
+    private function validateCreators(int $tmdbId, array $dwCreators, float $relativeDistance = 0.8): bool
+    {
+        $count = count($dwCreators);
+        $found = 0;
+
+        $queryUrl = 'https://api.themoviedb.org/3/movie/'.$tmdbId.'/credits';
+        $responseData = $this->sendRequest($queryUrl);
+
+        $tmdbCrew = [];
+        $priorityJobs = ['Director', 'Screenplay'];
+        foreach ($responseData->crew as $crewMember) {
+            if (in_array($crewMember->job, $priorityJobs)) {
+                $name = trim(mb_strtolower($crewMember->name, 'UTF-8'));
+                $tmdbCrew[$name] = $name;
+            }
+        }
+
+        // There can never be more matches than the lowest count of "$dwCreators" and "$tmdbCrew"
+        $count = $count < count($tmdbCrew) ? $count : count($tmdbCrew);
+
+        foreach ($dwCreators as $dwCreator) {
+            foreach ($tmdbCrew as $crew) {
+                $dwCreator = mb_strtolower($dwCreator, 'UTF-8');
+
+                $dl = new DamerauLevenshtein($dwCreator, $crew);
+
+                if ($crew === $dwCreator || $relativeDistance < $dl->getRelativeDistance()) {
+                    ++$found;
+                    break;
+                }
+            }
+        }
+
+        return $count > 0 && $count === $found;
+    }
+
+    /**
+     * Check for match between the TMDB and Datawell titles.
+     *
+     * @param string $tmdbTitle
+     * @param string $tmdbOrigTitle
+     * @param string $dwTitle
+     * @param string $dwOriginalTitle
+     * @param float $relativeDistance
+     * @param int $minLength
+     *
+     * @return bool
+     */
+    private function getTitlesHasMatch(string $tmdbTitle, string $tmdbOrigTitle, string $dwTitle, string $dwOriginalTitle, float $relativeDistance = 0.8, int $minLength = 5): bool
+    {
+        // Lowercase all strings for comparison.
+        $tmdbTitle = mb_strtolower($tmdbTitle, 'UTF-8');
+        $tmdbOrigTitle = mb_strtolower($tmdbOrigTitle, 'UTF-8');
+        $dwTitle = mb_strtolower($dwTitle, 'UTF-8');
+        $dwOriginalTitle = mb_strtolower($dwOriginalTitle, 'UTF-8');
+
+        return $this->getTitleContained($tmdbTitle, $tmdbOrigTitle, $dwTitle, $dwOriginalTitle, $minLength)
+            || $this->getTitlesMatchByDistance($tmdbTitle, $tmdbOrigTitle, $dwTitle, $dwOriginalTitle, $relativeDistance);
+    }
+
+    /**
+     * Check if TMDB and Datawell titles match by distance.
+     *
+     * Uses relative distance of Damerau Levenshtein to determine if there
+     * is a match between the datawell titles and the TMDB titles.
+     *
+     * @see https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+     *
+     * @param string $tmdbTitle
+     * @param string $tmdbOrigTitle
+     * @param string $dwTitle
+     * @param string $dwOriginalTitle
+     * @param float $relativeDistance
+     *
+     * @return bool
+     */
+    private function getTitlesMatchByDistance(string $tmdbTitle, string $tmdbOrigTitle, string $dwTitle, string $dwOriginalTitle, float $relativeDistance): bool
+    {
+        $dls = [];
+        $dls[] = new DamerauLevenshtein($tmdbTitle, $dwTitle);
+        $dls[] = new DamerauLevenshtein($tmdbTitle, $dwOriginalTitle);
+        $dls[] = new DamerauLevenshtein($tmdbOrigTitle, $dwTitle);
+        $dls[] = new DamerauLevenshtein($tmdbOrigTitle, $dwOriginalTitle);
+
+        foreach ($dls as $dl) {
+            if ($relativeDistance < $dl->getRelativeDistance()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the Datawell title(s) are contained in the TMDB titles.
+     *
+     * The Datawell sometimes has a shorter title than TMDB. E.g.
+     * "Heroes & Villains: Napoleon" vs. "Napoleon"
+     *
+     * @param string $tmdbTitle
+     * @param string $tmdbOrigTitle
+     * @param string $dwTitle
+     * @param string $dwOriginalTitle
+     * @param int $minLength
+     *
+     * @return bool
+     */
+    private function getTitleContained(string $tmdbTitle, string $tmdbOrigTitle, string $dwTitle, string $dwOriginalTitle, int $minLength): bool
+    {
+        $loop = [
+            $tmdbTitle => [$dwTitle, $dwOriginalTitle],
+            $tmdbOrigTitle => [$dwTitle, $dwOriginalTitle],
+            $dwTitle => [$tmdbTitle, $tmdbOrigTitle],
+            $dwOriginalTitle => [$tmdbTitle, $tmdbOrigTitle],
+        ];
+
+        foreach ($loop as $haystack => $needles) {
+            foreach ($needles as $needle) {
+                if (strlen($needle) >= $minLength) {
+                    if (str_starts_with($haystack, $needle) || str_ends_with($haystack, $needle)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
      * Get the poster url for a search result.
      *
+     * @param \stdClass $result
      *   The result to create poster url from
+     *
+     * @return string|null
      *   The poster url or null
      */
     private function getPosterUrl(\stdClass $result): ?string
@@ -198,7 +394,7 @@ class TheMovieDatabaseApiClient
             $content = $response->getContent();
 
             return json_decode($content, false, 512, JSON_THROW_ON_ERROR);
-        } catch (HttpExceptionInterface|TransportExceptionInterface|\JsonException|\Exception $e) {
+        } catch (ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface|TransportExceptionInterface|\JsonException|\Exception $e) {
             return new \stdClass();
         }
     }

--- a/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
+++ b/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
@@ -9,6 +9,7 @@ namespace App\Service\VendorService\TheMovieDatabase;
 
 use App\Service\DataWell\DataWellClient;
 use App\Service\VendorService\AbstractDataWellVendorService;
+use PrinsFrank\Standards\Language\ISO639_2_Alpha_3_Common;
 
 /**
  * Class TheMovieDatabaseVendorService.
@@ -43,27 +44,55 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService
         $data = [];
 
         if (isset($jsonContent->searchResponse?->result?->searchResult)) {
-            foreach ($jsonContent->searchResponse?->result?->searchResult as $searchResult) {
-                foreach ($searchResult->collection?->object as $object) {
+            foreach ($jsonContent->searchResponse?->result?->searchResult ?? [] as $searchResult) {
+                foreach ($searchResult->collection?->object ?? [] as $object) {
                     $pid = $object->identifier->{'$'};
                     $record = $object->record;
 
-                    $title = property_exists($record, 'title') ? $record->title[0]->{'$'} : null;
-                    $date = property_exists($record, 'date') ? $record->date[0]->{'$'} : null;
+                    // Match logic currently doesn't handle TV-shows
+                    $workType = property_exists($record, 'subject') ? $this->getWorkType($record->subject) : WorkType::UNKNOWN;
+                    if (WorkType::MOVIE === $workType) {
+                        $title = property_exists($record, 'title') ? $record->title[0]->{'$'} : null;
+                        $title = $title ? $this->getSanitizedTitle($title) : null;
 
-                    if ($title && $date) {
-                        $descriptions = property_exists($record, 'description') ? $record->description : [];
-                        $originalYear = $this->getOriginalYear($descriptions);
-                        $creators = property_exists($record, 'creator') ? $record->creator : [];
-                        $director = $this->getDirector($creators);
+                        $originalTitle = property_exists($record, 'alternative') ? $record->alternative[0]->{'$'} : '';
 
-                        $posterUrl = $this->api->searchPosterUrl(
-                            title: $title,
-                            originalYear: $originalYear,
-                            director: $director
-                        );
+                        $date = property_exists($record, 'date') ? $record->date[0]->{'$'} : null;
 
-                        $data[$pid] = $posterUrl;
+                        if ($title && $date) {
+                            $descriptions = property_exists($record, 'description') ? $record->description : [];
+                            $subjects = property_exists($record, 'subject') ? $record->subject : [];
+
+                            // Year must be extracted from descriptions. Datawell "date" is the
+                            // disc publication date. Not the movie release year.
+                            $originalYear = $this->getOriginalYear($descriptions, $subjects);
+
+                            // Datawell year can be "of by one" in either direction relative
+                            // to TMDB. Go figure ...
+                            $originalYears = (null !== $originalYear) ? [
+                                $originalYear,
+                                $originalYear - 1,
+                                $originalYear + 1,
+                            ] : [];
+
+                            $creators = property_exists($record, 'creator') ? $record->creator : [];
+                            $creators = $this->getCreators($creators);
+
+                            $languages = property_exists($record, 'language') ? $record->language : [];
+                            $audioLanguages = $this->getAudioLanguages($languages);
+                            $subtitleLanguages = $this->getSubtitleLanguages($languages);
+                            $searchLanguage = $this->getSearchLanguage($audioLanguages, $subtitleLanguages);
+
+                            $posterUrl = $this->api->searchPosterUrl(
+                                title: $title,
+                                originalTitle: $originalTitle,
+                                originalYears: $originalYears,
+                                creators: $creators,
+                                language: $searchLanguage,
+                            );
+
+                            $data[$pid] = $posterUrl;
+                        }
                     }
                 }
             }
@@ -73,23 +102,150 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService
     }
 
     /**
+     * Guess the work type (movie or tv-show) based on the datawell result.
+     *
+     * @TODO Currently has high number of tv-show that gets marked as movies.
+     *
+     * @param array $subjects
+     *
+     * @return WorkType
+     */
+    private function getWorkType(array $subjects): WorkType
+    {
+        $searchDkcdPlus = ['dkdcplus:DK5-Text', 'dkdcplus:DBCS', 'dkdcplus:genre'];
+
+        $types = [];
+
+        foreach ($subjects as $subject) {
+            if (property_exists($subject, '@type')) {
+                if (in_array($subject->{'@type'}->{'$'}, $searchDkcdPlus)) {
+                    $types[] = mb_strtolower($subject->{'$'});
+                }
+
+                if ('dcterms:LCSH' === $subject->{'@type'}->{'$'}) {
+                    if (str_ends_with($subject->{'$'}, ' films')) {
+                        $types[] = 'spillefilm';
+                    }
+                }
+            }
+        }
+
+        // Order is important. A TV Show will also have the
+        // subject "Spillefilm" but a movie will not have the
+        // subject "tv-serier".
+        // @TODO match by title also and look for "Disc, Episode, etc"?
+        if (in_array('tv-serier', $types)) {
+            return WorkType::TV_SHOW;
+        }
+
+        if (in_array('spillefilm', $types)) {
+            return WorkType::MOVIE;
+        }
+
+        return WorkType::UNKNOWN;
+    }
+
+    /**
+     * Get the search language.
+     *
+     * If the result has danish as either audio- or subtitle language we assume
+     * it is an edition for the danish marked and search for a danish cover. Else
+     * we default to the first audio, first subtitle then english language.
+     *
+     * @param array $audioLanguages
+     * @param array $subtitleLanguages
+     *
+     * @return string
+     */
+    private function getSearchLanguage(array $audioLanguages, array $subtitleLanguages): string
+    {
+        $audioLanguages = array_map('mb_strtolower', $audioLanguages);
+        $subtitleLanguages = array_map('mb_strtolower', $subtitleLanguages);
+
+        if (in_array('da', $audioLanguages) || in_array('dansk', $subtitleLanguages)) {
+            return 'da';
+        } elseif (!empty($audioLanguages)) {
+            return $audioLanguages[0];
+        } elseif (!empty($subtitleLanguages)) {
+            return $subtitleLanguages[0];
+        } else {
+            return 'en';
+        }
+    }
+
+    /**
+     * Get audio language codes from result.
+     *
+     * @param array $languages
+     *
+     * @return string[]
+     */
+    private function getAudioLanguages(array $languages): array
+    {
+        $audioLanguages = [];
+
+        // Get all audio languages from type "dcterms:ISO639-2"
+        foreach ($languages as $language) {
+            if (isset($language->{'@type'}?->{'$'}) && 'dcterms:ISO639-2' === $language->{'@type'}?->{'$'}) {
+                if (isset($language->{'$'})) {
+                    // Translate language code from "xyz" to "xy", e.g. "dan" to "da"
+                    $lang = ISO639_2_Alpha_3_Common::tryFrom($language->{'$'})?->toISO639_1_Alpha_2()?->value;
+                    if (null !== $lang) {
+                        $audioLanguages[] = $lang;
+                    }
+                }
+            }
+        }
+
+        return $audioLanguages;
+    }
+
+    /**
+     * Get subtitle language codes from result.
+     *
+     * @param array $languages
+     *
+     * @return string[]
+     */
+    private function getSubtitleLanguages(array $languages): array
+    {
+        $subtitleLanguages = [];
+
+        // Get all subtitle languages from type "dkdcplus:subtitles"
+        foreach ($languages as $language) {
+            if (isset($language->{'@type'}?->{'$'}) && 'dkdcplus:subtitles' === $language->{'@type'}?->{'$'}) {
+                if (isset($language->{'$'})) {
+                    $subtitleLanguages[] = $language->{'$'};
+                }
+            }
+        }
+
+        return $subtitleLanguages;
+    }
+
+    /**
      * Extract the original year from the descriptions.
+     *
+     * The descriptions follow the format "Bla, bal, bla 1984", so we find all
+     * descriptions that end in a 4-digit number. Then pick the lowest e.g. the
+     * chronologically first. We can't use the "date" field from the result
+     * because this refers to the data added in the data well.
      *
      * @param array $descriptions
      *   Search array of descriptions
      *
-     * @return ?string The original year or null
+     * @return ?int The original year or null
      */
-    private function getOriginalYear(array $descriptions): ?string
+    private function getOriginalYear(array $descriptions, array $subjects): ?int
     {
         $matches = [];
 
-        foreach ($descriptions as $description) {
-            $descriptionMatches = [];
-            $match = preg_match('/(\d{4})/u', (string) $description->{'$'}, $descriptionMatches);
+        foreach (array_merge($descriptions, $subjects) as $subject) {
+            $subjectMatches = [];
+            $match = preg_match('/(\d{4})$/u', (string) $subject->{'$'}, $subjectMatches);
 
             if ($match) {
-                $matches = array_unique(array_merge($matches, $descriptionMatches));
+                $matches = array_unique(array_merge($matches, $subjectMatches));
             }
         }
 
@@ -97,45 +253,81 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService
         $confirmedMatches = [];
 
         foreach ($matches as $matchString) {
-            $match = (int) $matchString;
+            $match = intval($matchString);
 
-            if ($match > 1850 && $match < $upperYear) {
-                $confirmedMatches[] = $matchString;
+            // "Roundhay Garden Scene ... is believed to be the oldest surviving film in existence."
+            // https://en.wikipedia.org/wiki/Roundhay_Garden_Scene
+            if ($match > 1888 && $match < $upperYear) {
+                $confirmedMatches[] = $match;
             }
         }
 
-        if (1 === count($confirmedMatches)) {
-            return $confirmedMatches[0];
-        }
+        // Ensure matches are ordered chronologically
+        sort($confirmedMatches);
 
-        return null;
+        return $confirmedMatches[0] ?? null;
     }
 
     /**
-     * Extract the director from the creators.
+     * Extract the creators from the DC list creators excluding sort entries.
      *
      * @param array $creators
      *   Search array of creators
      *
-     *   The director or null
+     * @return array
      */
-    private function getDirector(array $creators): ?string
+    private function getCreators(array $creators): array
     {
-        $directors = [];
+        $filtered = [];
 
         foreach ($creators as $creator) {
-            if (isset($creator->{'@type'}?->{'$'}) && 'dkdcplus:drt' === $creator->{'@type'}?->{'$'}) {
-                if (isset($creator->{'$'})) {
-                    $directors[] = $creator->{'$'};
+            // The "oss:sort" is a duplicate entry for sorting. E.g " Koster, Henry" for "Henry Koster"
+            if (isset($creator->{'$'})) {
+                if (!isset($creator->{'@type'}?->{'$'}) || (isset($creator->{'@type'}?->{'$'}) && 'oss:sort' !== $creator->{'@type'}?->{'$'})) {
+                    $name = $this->getSanitizedCreator($creator->{'$'});
+                    $filtered[$name] = $name;
                 }
             }
         }
 
-        // @TODO: Can there be more directors?
-        if (count($directors) > 0) {
-            return $directors[0];
+        return $filtered;
+    }
+
+    /**
+     * Get the sanitized title without additional text added by the datawell.
+     *
+     * @param string $datawellTitle
+     *
+     * @return string
+     */
+    private function getSanitizedTitle(string $datawellTitle): string
+    {
+        // E.g. "Game of thrones" for "Game of thrones. Sæson 2. Disc 3, episodes 5, 6 & 7".
+        $pos = mb_stripos($datawellTitle, '. Sæson', 0, 'UTF-8');
+        if ($pos > 0) {
+            $datawellTitle = mb_substr($datawellTitle, 0, $pos, 'UTF-8');
         }
 
-        return null;
+        return trim($datawellTitle);
+    }
+
+    /**
+     * Get the sanitized creator name without additional text added by the datawell.
+     *
+     * @param string $datawellName
+     *
+     * @return string
+     */
+    private function getSanitizedCreator(string $datawellName): string
+    {
+        // E.g. "Henry Koster" for "Henry Koster (1905-1988)".
+        // E.g. "Elizabeth Sellars" for "Elizabeth Sellars (1923-)"
+        // E.g. "George Miller" for "George Miller (1945 March 3-)"
+        // E.g. "Margaret Mitchell" for "Margaret Mitchell (f. 1900)"
+        $datawellName = preg_replace('/(\(.*\d{4}).*\)$/', '', $datawellName);
+
+        // Margaret Mitchell (f. 1900)
+
+        return trim($datawellName);
     }
 }

--- a/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
+++ b/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
@@ -62,7 +62,7 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService implem
             $item->setIdentifier($identifier);
             $item->setIdentifierType($type);
             $item->setVendor($vendor);
-            $item->setOriginalFile($this->getVendorsImageUrl($identifier));
+            $item->setOriginalFile($pidArray[$identifier]);
 
             return $item;
         }

--- a/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
+++ b/src/Service/VendorService/TheMovieDatabase/TheMovieDatabaseVendorService.php
@@ -311,12 +311,13 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService implem
     }
 
     /**
-     * Extract the creators from the DC list creators excluding sort entries.
+     * Extract the creators from the datawell creators excluding sort entries.
      *
      * @param array $creators
      *   Search array of creators
      *
      * @return array
+     *   Array of sanitized creator names excluding "oss:sort" duplicates or empty array if none found
      */
     private function getCreators(array $creators): array
     {
@@ -339,8 +340,10 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService implem
      * Get the sanitized title without additional text added by the datawell.
      *
      * @param string $datawellTitle
+     *   The title to sanitize
      *
      * @return string
+     *   The sanitized title
      */
     private function getSanitizedTitle(string $datawellTitle): string
     {
@@ -357,8 +360,10 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService implem
      * Get the sanitized creator name without additional text added by the datawell.
      *
      * @param string $datawellName
+     *   The name to sanitize
      *
      * @return string
+     *   The sanitized name
      */
     private function getSanitizedCreator(string $datawellName): string
     {
@@ -367,8 +372,6 @@ class TheMovieDatabaseVendorService extends AbstractDataWellVendorService implem
         // E.g. "George Miller" for "George Miller (1945 March 3-)"
         // E.g. "Margaret Mitchell" for "Margaret Mitchell (f. 1900)"
         $datawellName = preg_replace('/(\(.*\d{4}).*\)$/', '', $datawellName);
-
-        // Margaret Mitchell (f. 1900)
 
         return trim($datawellName);
     }

--- a/src/Service/VendorService/TheMovieDatabase/WorkType.php
+++ b/src/Service/VendorService/TheMovieDatabase/WorkType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Service\VendorService\TheMovieDatabase;
+
+enum WorkType
+{
+    case TV_SHOW;
+    case MOVIE;
+    case UNKNOWN;
+}

--- a/src/Service/VendorService/VendorServiceSingleIdentifierInterface.php
+++ b/src/Service/VendorService/VendorServiceSingleIdentifierInterface.php
@@ -21,12 +21,12 @@ interface VendorServiceSingleIdentifierInterface extends VendorServiceInterface
      * @param string $type
      *   The identifier type
      *
-     * @return UnverifiedVendorImageItem
+     * @return UnverifiedVendorImageItem|null
      *
      * @throws UnsupportedIdentifierTypeException
      * @throws UnknownVendorServiceException
      */
-    public function getUnverifiedVendorImageItem(string $identifier, string $type): UnverifiedVendorImageItem;
+    public function getUnverifiedVendorImageItem(string $identifier, string $type): ?UnverifiedVendorImageItem;
 
     /**
      * Does the vendor support this identifier type.


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/DDBTEAM-1051

Depends on https://github.com/danskernesdigitalebibliotek/ddb-cover-service-importers/pull/128

#### Description

- TheMovieDatabaseVendor has been refactored to use the Abstract DatawellVendor.
- TheMovieDatabaseVendor now supports single cover no hits processing. 
- Match logic for TheMovieDatabaseVendor has been refactored for better matching.
- VendorServiceSingleIdentifierInterface now has nullable return.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
